### PR TITLE
Fix undefined name "floor" in f_boundary.py

### DIFF
--- a/functional/utils/f_boundary.py
+++ b/functional/utils/f_boundary.py
@@ -124,8 +124,8 @@ def seg2bmap(seg,width=None,height=None):
         for x in range(w):
             for y in range(h):
                 if b[y,x]:
-                    j = 1+floor((y-1)+height / h)
-                    i = 1+floor((x-1)+width  / h)
+                    j = 1+np.floor((y-1)+height / h)
+                    i = 1+np.floor((x-1)+width  / h)
                     bmap[j,i] = 1;
 
     return bmap

--- a/logger.py
+++ b/logger.py
@@ -15,7 +15,7 @@ def setup_logger(filepath):
     file_handle_name = "file"
     if file_handle_name in [h.name for h in logger.handlers]:
         return
-    if os.path.dirname(filepath) is not '':
+    if os.path.dirname(filepath) != '':
         if not os.path.isdir(os.path.dirname(filepath)):
             os.makedirs(os.path.dirname(filepath))
     file_handle = logging.FileHandler(filename=filepath, mode="a")


### PR DESCRIPTION
https://docs.scipy.org/doc/numpy/reference/generated/numpy.floor.html

[flake8](http://flake8.pycqa.org) testing of https://github.com/zlai0/CorrFlow on Python 3.7.1

$ __flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics__
```
./logger.py:18:8: F632 use ==/!= to compare str, bytes, and int literals
    if os.path.dirname(filepath) is not '':
       ^
./benchmark.py:76:26: F821 undefined name 'output'
                anno_0 = output
                         ^
./test.py:75:26: F821 undefined name 'output'
                anno_0 = output
                         ^
./main_oxuva.py:144:54: F821 undefined name 'outputs'
        ref_c = image_q[i] if truth or (i == 0) else outputs
                                                     ^
./main_oxuva.py:165:25: F821 undefined name 'outputs'
                ref_c = outputs
                        ^
./main.py:139:54: F821 undefined name 'outputs'
        ref_c = image_q[i] if truth or (i == 0) else outputs
                                                     ^
./main.py:160:25: F821 undefined name 'outputs'
                ref_c = outputs
                        ^
./functional/utils/f_boundary.py:127:27: F821 undefined name 'floor'
                    j = 1+floor((y-1)+height / h)
                          ^
./functional/utils/f_boundary.py:128:27: F821 undefined name 'floor'
                    i = 1+floor((x-1)+width  / h)
                          ^
1     F632 use ==/!= to compare str, bytes, and int literals
8     F821 undefined name 'output'
9
```
__E901,E999,F821,F822,F823__ are the "_showstopper_" [flake8](http://flake8.pycqa.org) issues that can halt the runtime with a SyntaxError, NameError, etc. These 5 are different from most other flake8 issues which are merely "style violations" -- useful for readability but they do not effect runtime safety.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable name referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree